### PR TITLE
Path finder added

### DIFF
--- a/lcpp.lua
+++ b/lcpp.lua
@@ -103,8 +103,6 @@
 -- @module lcpp
 local lcpp = {}
 
-
-
 -- check bit is avail or not
 local ok, bit = pcall(require, 'bit')
 if not ok then


### PR DESCRIPTION
This patch provide find in filesystem, not only in current directory.

To set system patches, use lcpp.PATH as in example: "/usr/include;/usr/local/include;/include"